### PR TITLE
Keeping only ELK stack

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,6 +1,6 @@
-mod 'puppetlabs/apache', '1.6.0'
-mod 'puppetlabs/stdlib', '4.9.0'
-mod 'puppetlabs/vcsrepo', '1.3.1'
-mod 'puppetlabs/concat', '1.2.4'
-mod 'puppetlabs/mysql', '3.6.2'
-mod 'nanliu/staging', '1.0.3'
+#dependencies
+mod 'puppetlabs-stdlib', '8.5.0'
+mod 'puppetlabs-apt', '9.0.0'
+mod 'puppet-yum', '6.1.0'
+mod 'puppetlabs-concat', '7.3.0'
+mod 'puppet-elastic_stack', '8.0.2'


### PR DESCRIPTION
Keeping only the ELK stack, removing Apache because dependency modules generate conflicts with ELK stack